### PR TITLE
Task 37/destroy cars on restart

### DIFF
--- a/SettingsPanel.cpp
+++ b/SettingsPanel.cpp
@@ -138,14 +138,15 @@ SettingsPanel::SettingsPanel(int screenWidth, int screenHeight, int btnPadding, 
 }
 
 void SettingsPanel::toggle(){
+    if(simulation->isStarted) simulation->startToggle();
     setVisible(!isVisible());
 }
 
 void SettingsPanel::restart(){
-    toggle();
     simulation->resetTimer();
     simulation->statisticsPanel->reset();
-    simulation->start();
+    simulation->destroyAllVehicles();
+    toggle();
 }
 
 void SettingsPanel::toggleTrafficLights(){

--- a/Simulation.cpp
+++ b/Simulation.cpp
@@ -46,7 +46,7 @@ Simulation::Simulation(QWidget *parent){
     setFixedSize(screenWidth,screenHeight);
 
     // Initial Settings
-    simulationStarted = false;
+    isStarted = false;
     mm= ss= 0;
 
     drawGUI();
@@ -59,9 +59,9 @@ Simulation::Simulation(QWidget *parent){
     show();
 }
 
-void Simulation::start(){
-    simulationStarted = !simulationStarted;
-    if(simulationStarted){
+void Simulation::startToggle(){
+    isStarted = !isStarted;
+    if(isStarted){
         playButton->setText("Stop");
         playButton->setColor(Qt::red);
         timer->start(1000/(settingsPanel->vehiclesPerSec));
@@ -69,6 +69,12 @@ void Simulation::start(){
         playButton->setText("Start");
         playButton->setColor(Qt::darkGreen);
         timer->stop();
+    }
+}
+
+void Simulation::destroyAllVehicles(){
+    foreach(Vehicle* v, aliveVehicles){
+        v->selfDestruct();
     }
 }
 
@@ -89,6 +95,7 @@ void Simulation::addVehicle(){
     int pickedSpawnOption = (rand() % 16);
     Vehicle *vehicle = new Vehicle(settingsPanel->speedRangeLowerBound, settingsPanel->speedRangeUpperBound, spawnOptions[pickedSpawnOption]);
     scene->addItem(vehicle);
+    aliveVehicles.append(vehicle);
 }
 
 void Simulation::drawGUI(){
@@ -124,7 +131,7 @@ void Simulation::drawGUI(){
 
     playButton = new Button(QString("Start "), Qt::darkGreen, playBtnW, playBtnH, 0, 0, bottomPanel);
     playButton->setPos(playBtnX,playBtnY);
-    connect(playButton,SIGNAL(clicked()),this,SLOT(start()));
+    connect(playButton,SIGNAL(clicked()),this,SLOT(startToggle()));
 
     statisticsPanel = new StatisticsPanel(screenWidth, screenHeight, btnPadding, bottomPanel);
     drawTrafficLights();

--- a/Simulation.h
+++ b/Simulation.h
@@ -8,6 +8,7 @@
 #include "SettingsPanel.h"
 #include "StatisticsPanel.h"
 #include "SpawnOption.h"
+#include "vehicle.h"
 
 class Simulation: public QGraphicsView{
     Q_OBJECT
@@ -18,17 +19,19 @@ public:
     QTimer* timer;
     SettingsPanel* settingsPanel;
     StatisticsPanel* statisticsPanel;
-    bool simulationStarted;
+    bool isStarted;
     Button* playButton;
     void decrementCarsOnScreen();
     QGraphicsRectItem* drawPanel(int x, int y, int width, int height, QColor color, double opacity);
     void addSpawnOptions();
     void destroyCollidingVehicles(QList<QGraphicsItem *> list);
+    void destroyAllVehicles();
     int mm,ss;
     QGraphicsTextItem* displayTimer;
+    QList<Vehicle*> aliveVehicles;
 
 public slots:
-    void start();
+    void startToggle();
     void addVehicle();
     void drawTrafficLights();
     void drawTimer();

--- a/vehicle.cpp
+++ b/vehicle.cpp
@@ -30,6 +30,9 @@ Vehicle::Vehicle(int speedRangeLowerBound, int speedRangeUpperBound, SpawnOption
 }
 
 void Vehicle::move(){
+    // check if simulation is paused
+    if(!(simulation->isStarted)) return;
+
     // detect collisions
     QList<QGraphicsItem *> list = scene()->collidingItems(this);
     if(!(list.isEmpty())){
@@ -100,6 +103,7 @@ void Vehicle::move(){
 
 void Vehicle::selfDestruct(){
     simulation->decrementCarsOnScreen();
+    simulation->aliveVehicles.removeOne(this);
     scene()->removeItem(this);
     delete this;
 }


### PR DESCRIPTION
- Cars now pause on simulation pause
- All vehicles destroyed on simulation restart
- Fixed settings toggle bug
- Added alive vehicles lists to `Simulation`